### PR TITLE
/home/user may not be the default user's home dir

### DIFF
--- a/qvm-move-to-chosen-vm
+++ b/qvm-move-to-chosen-vm
@@ -10,5 +10,5 @@ vm=$(
 
 if [ -n "$vm" ]; then
 	qvm-move-to-vm "$vm" "$@"
-	qvm-run -p "$vm" 'xdg-open /home/user/QubesIncoming/dom0' </dev/null
+	qvm-run -p "$vm" 'xdg-open ~/QubesIncoming/dom0' </dev/null
 fi


### PR DESCRIPTION
Instead, use tilde expansion to pick the correct home directory every time.